### PR TITLE
add dynamic contributor stats with count-up animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,6 +103,25 @@
     </nav>
 
 <!-- NAVBAR END -->
+ <!-- 🔢 CONTRIBUTOR STATS -->
+<section class="stats-container">
+    <div class="stat-card">
+        <span id="totalCount">0</span>
+        <p>Total Members</p>
+    </div>
+    <div class="stat-card">
+        <span id="devCount">0</span>
+        <p>Developers</p>
+    </div>
+    <div class="stat-card">
+        <span id="contributorCount">0</span>
+        <p>Contributors</p>
+    </div>
+    <div class="stat-card">
+        <span id="maintainerCount">0</span>
+        <p>Maintainers</p>
+    </div>
+</section>
 
     <!-- Main heading of the website -->
 
@@ -526,6 +545,46 @@ toggleBtn.addEventListener("click", () => {
         localStorage.setItem("theme", "dark");
     }
 });
+</script>
+<script>
+function animateValue(element, start, end, duration) {
+    let startTimestamp = null;
+
+    function step(timestamp) {
+        if (!startTimestamp) startTimestamp = timestamp;
+        const progress = Math.min((timestamp - startTimestamp) / duration, 1);
+        element.innerText = Math.floor(progress * (end - start) + start);
+        if (progress < 1) {
+            window.requestAnimationFrame(step);
+        }
+    }
+
+    window.requestAnimationFrame(step);
+}
+
+function updateContributorStats() {
+    const cards = document.querySelectorAll(".card");
+
+    let total = cards.length;
+    let dev = 0;
+    let contributor = 0;
+    let maintainer = 0;
+
+    cards.forEach(card => {
+        const role = card.querySelector(".role")?.innerText.toLowerCase();
+
+        if (role.includes("developer")) dev++;
+        else if (role.includes("maintainer")) maintainer++;
+        else contributor++;
+    });
+
+    animateValue(document.getElementById("totalCount"), 0, total, 800);
+    animateValue(document.getElementById("devCount"), 0, dev, 800);
+    animateValue(document.getElementById("contributorCount"), 0, contributor, 800);
+    animateValue(document.getElementById("maintainerCount"), 0, maintainer, 800);
+}
+
+document.addEventListener("DOMContentLoaded", updateContributorStats);
 </script>
 
 

--- a/style.css
+++ b/style.css
@@ -1026,3 +1026,35 @@ body.light-mode {
   );
   transition: transform 0.1s, left 0.1s, top 0.1s;
 }
+
+/* ==========================
+   CONTRIBUTOR STATS
+   ========================== */
+.stats-container {
+    display: flex;
+    justify-content: center;
+    gap: 12px;
+    margin: 20px auto;
+    flex-wrap: wrap;
+}
+
+.stat-card {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    padding: 10px 14px;
+    border-radius: 10px;
+    text-align: center;
+    min-width: 110px;
+}
+
+.stat-card span {
+    font-size: 20px;
+    font-weight: 700;
+    color: var(--primary-color);
+}
+
+.stat-card p {
+    font-size: 12px;
+    margin-top: 4px;
+    color: var(--secondary-text);
+}


### PR DESCRIPTION
Added a compact contributor statistics section to the homepage that dynamically calculates total members and role-wise distribution (Developers, Contributors, Maintainers) by traversing existing contributor cards in the DOM. The stats automatically update as new cards are added and include a smooth count-up animation on page load. The UI is intentionally kept minimal and fully compatible with both light and dark themes to maintain consistency with the existing design.



https://github.com/user-attachments/assets/1feeb619-3bfe-455c-a47c-6d37ea72c5a1

