### PR TITLE
feat: add grid and compact view toggle for contributor cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,6 +135,10 @@
         <option value="za">Z-A</option>
         <option value="newest">Newest First</option>
     </select>
+    <button id="viewToggle" class="view-toggle-btn" aria-label="Toggle View">
+    <i class="fas fa-list"></i>
+</button>
+
 </section>
     
 
@@ -796,6 +800,23 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 });
 </script>
+<script>
+const viewToggle = document.getElementById("viewToggle");
+const cardContainer = document.querySelector(".card-container");
+
+viewToggle.addEventListener("click", () => {
+    cardContainer.classList.toggle("compact-view");
+
+    // Toggle icon
+    const icon = viewToggle.querySelector("i");
+    if (cardContainer.classList.contains("compact-view")) {
+        icon.classList.replace("fa-list", "fa-th-large");
+    } else {
+        icon.classList.replace("fa-th-large", "fa-list");
+    }
+});
+</script>
+
 
 </body>
 

--- a/style.css
+++ b/style.css
@@ -2351,3 +2351,74 @@ html {
         justify-content: center;
     }
 }
+
+/* ===============================
+   COMPACT VIEW MODE
+   =============================== */
+
+.card-container.compact-view {
+    grid-template-columns: 1fr;
+    gap: 16px;
+}
+
+/* Compact card layout */
+.card-container.compact-view .card {
+    flex-direction: row;
+    align-items: center;
+    min-height: auto;
+    padding: 16px 20px;
+    text-align: left;
+}
+
+/* Smaller image */
+.card-container.compact-view .card-img {
+    width: 70px;
+    height: 70px;
+    margin: 0 20px 0 0;
+}
+
+/* Align content horizontally */
+.card-container.compact-view .card-inner {
+    flex-direction: row;
+    align-items: center;
+    gap: 20px;
+}
+
+/* Text tweaks */
+.card-container.compact-view h2 {
+    font-size: 1.1rem;
+    margin: 0;
+}
+
+.card-container.compact-view .role {
+    font-size: 0.7rem;
+    padding: 4px 12px;
+    margin: 6px 0;
+}
+
+.card-container.compact-view p {
+    display: none; /* hide quotes for compactness */
+}
+
+/* Button smaller */
+.card-container.compact-view .card-btn {
+    padding: 8px 18px;
+    font-size: 0.8rem;
+    min-width: auto;
+}
+
+.view-toggle-btn {
+    padding: 10px 14px;
+    border-radius: 50%;
+    border: 1px solid var(--border-primary);
+    background: var(--bg-card);
+    color: var(--text-primary);
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+.view-toggle-btn:hover {
+    background: var(--primary-color);
+    color: var(--bg-primary);
+    transform: scale(1.05);
+}


### PR DESCRIPTION
### 🚀 Overview
This PR introduces a view toggle that allows users to switch between the default grid view and a compact list-style view for contributor cards.

### ✨ What’s New
- 🔄 Grid ↔ Compact view toggle near filter controls
- 📋 Compact view with smaller cards and reduced spacing
- ⚡ Instant toggle without page reload
- 🎨 Fully responsive and theme-aware
- 🔁 Resets on refresh (no localStorage used)

### 🧠 Why This Matters
As the number of contributors grows, browsing all cards in a grid can feel overwhelming.
The compact view improves readability and makes it easier to scan contributors quickly.

### 🛠 Tech Details
- Pure HTML, CSS, and JavaScript
- Class-based layout toggling
- No external libraries added
- Existing functionality remains untouched



https://github.com/user-attachments/assets/079f117d-e31e-4797-bcfc-1b4545778779

