### PR TITLE
Add .gitignore to exclude local, cache, and OS-specific files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,52 @@
+# Node dependencies
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Build or distribution directories
+build/
+dist/
+
+# Environment files
+.env
+.env.local
+.env.*.local
+
+# Logs
+logs/
+*.log
+
+# OS generated files
+.DS_Store
+Thumbs.db
+Desktop.ini
+
+# Editor/IDE files
+.vscode/
+.idea/
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.swp
+*~
+
+# Cache directories
+.cache/
+.cache-loader/
+npm-cache/
+*.tmp
+
+# Optional npm cache
+.npm
+.eslintcache
+.stylelintcache
+
+# Optional coverage directory
+coverage/
+*.lcov
+
+# Misc
+*.tgz


### PR DESCRIPTION
fix #184 @Jayanta2004 
Added a .gitignore file to prevent committing unnecessary files such as local environment configs, dependency folders, cache files, editor settings, and OS-generated artifacts.