### PR TITLE
Fix Invisible Commands on Contribute Page Due to Background Styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -2350,7 +2350,7 @@ html {
     font-size: 1.1rem;
 }
 
-/* Code Block */
+/* Default (Dark Theme) */
 .code-block {
     background: #0f172a;
     padding: 15px;
@@ -2362,11 +2362,22 @@ html {
 
 .code-block code {
     font-family: 'Fira Code', monospace;
-    color: var(--text-primary);
+    color: #e5e7eb;
     font-size: 0.85rem;
     display: block;
     overflow-x: auto;
 }
+
+/* Light Theme Fix */
+.light-theme .code-block {
+    background: #f8fafc;            /* light background */
+    border: 1px solid #e2e8f0;
+}
+
+.light-theme .code-block code {
+    color: #0f172a;                 /* dark readable text */
+}
+
 
 .copy-btn {
     position: absolute;


### PR DESCRIPTION
fix #192 
@Jayanta2004 

# before
<img width="1302" height="350" alt="Screenshot 2026-01-08 104120" src="https://github.com/user-attachments/assets/3bc42001-c280-4815-8119-57ee85c26eda" />

# after
<img width="1196" height="311" alt="image" src="https://github.com/user-attachments/assets/8dbf3ccc-2da4-4bbb-b36b-8f8edfb76892" />
