### PR TITLE
Feature/project view toggle

### DIFF
--- a/projects.html
+++ b/projects.html
@@ -9,6 +9,67 @@
     <link rel="stylesheet" href="style.css" />
     <link rel="icon" type="image/png" href="Hall of Fame (1).png" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <style>
+    /* Projects grid vs compact (row) view */
+    .projects-container {
+        max-width: 1200px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: 20px;
+        padding: 0 20px 40px;
+        box-sizing: border-box;
+    }
+
+    .project-card {
+        background: var(--bg-card);
+        border: 1px solid var(--border-secondary);
+        padding: 16px;
+        border-radius: 12px;
+        box-shadow: var(--shadow-sm);
+        transition: transform 0.15s ease, box-shadow 0.15s ease;
+        display: block;
+    }
+
+    .project-card:hover {
+        transform: translateY(-6px);
+        box-shadow: var(--shadow-md);
+    }
+
+    .project-desc { color: var(--text-secondary); margin: 8px 0; }
+
+    .project-tags { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 8px; }
+    .project-tags span {
+        background: rgba(255,255,255,0.03);
+        padding: 6px 8px;
+        border-radius: 8px;
+        font-size: 0.8rem;
+        color: var(--text-secondary);
+    }
+
+    .project-links a { margin-right: 12px; text-decoration: none; color: var(--text-primary); font-weight: 600; }
+    .project-footer { margin-top: 12px; font-size: 0.85rem; color: var(--text-secondary); }
+
+    /* Compact (row/list) view */
+    .projects-container.compact-view {
+        display: block;
+        padding: 0 20px 40px;
+    }
+
+    .projects-container.compact-view .project-card {
+        display: flex;
+        gap: 16px;
+        align-items: center;
+        padding: 12px;
+    }
+
+    .projects-container.compact-view .project-card h2 { margin: 0; font-size: 1.05rem; }
+
+    @media (max-width: 600px) {
+        .projects-container { grid-template-columns: 1fr; }
+        .projects-container.compact-view .project-card { flex-direction: column; align-items: flex-start; }
+    }
+    </style>
 </head>
 
 <body>
@@ -39,6 +100,13 @@
         Learn, explore, and get inspired 🌱
     </p>
 </header>
+<!-- VIEW TOGGLE -->
+<div style="display:flex; justify-content:flex-end; max-width:1200px; margin:0 auto 20px; padding:0 20px;">
+    <button id="viewToggleBtn" class="view-toggle-btn" title="Toggle view">
+        <i class="fas fa-th-large"></i>
+    </button>
+</div>
+
 
 <!-- PROJECTS GRID -->
 <section class="projects-container">
@@ -90,6 +158,46 @@ hamburger.addEventListener("click", () => {
     navLinks.classList.toggle("active");
 });
 </script>
+<script>
+const viewToggleBtn = document.getElementById("viewToggleBtn");
+const projectsContainer = document.querySelector(".projects-container");
+
+let isCompact = false;
+
+viewToggleBtn.addEventListener("click", () => {
+    isCompact = !isCompact;
+
+    projectsContainer.classList.toggle("compact-view");
+
+    viewToggleBtn.innerHTML = isCompact
+        ? '<i class="fas fa-th-list"></i>'
+        : '<i class="fas fa-th-large"></i>';
+});
+</script>
+
+<script>
+const viewToggleBtn = document.getElementById("viewToggleBtn");
+const projectsContainer = document.querySelector(".projects-container");
+
+let isCompact = localStorage.getItem('projectsView') === 'compact';
+
+function applyView(compact) {
+    isCompact = compact;
+    projectsContainer.classList.toggle('compact-view', compact);
+    viewToggleBtn.innerHTML = compact
+        ? '<i class="fas fa-th-list"></i>'
+        : '<i class="fas fa-th-large"></i>';
+    viewToggleBtn.setAttribute('aria-pressed', compact ? 'true' : 'false');
+    viewToggleBtn.title = compact ? 'Switch to grid view' : 'Switch to list view';
+    localStorage.setItem('projectsView', compact ? 'compact' : 'grid');
+}
+
+viewToggleBtn.addEventListener('click', () => applyView(!isCompact));
+
+// Initialize on load
+applyView(isCompact);
+</script>
+
 
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -3172,3 +3172,6 @@ body.light-mode .welcome-message {
         font-size: 1.5rem;
     }
 }
+.projects-container.compact-view {
+    grid-template-columns: 1fr;
+}


### PR DESCRIPTION
## 📌 Description
This PR adds a layout toggle to the Projects page, allowing users to switch between the default grid view and a compact list-style view for easier browsing when many projects are present.

The feature is implemented using a frontend-only approach by toggling a CSS class, without modifying existing project card content or requiring a page reload.

Fixes: [#146](https://github.com/Jayanta2004/dev-card-showcase/issues/146)

---

## 🔧 Type of Change
Please mark the relevant option(s):

- [ ] 🐛 Bug fix
- [X ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor / Code cleanup
- [X ] 🎨 UI / Styling change
- [ ] 🚀 Other (please describe):

---

## 🧪 How Has This Been Tested?
Describe the tests you ran to verify your changes.

- [ X ] Manual testing
- [ ] Automated tests
- [ ] Not tested (please explain why)

---

## 📸 Screenshots (if applicable)
<img width="1341" height="895" alt="Screenshot 2026-01-08 170131" src="https://github.com/user-attachments/assets/29d98f23-a4ad-4cda-9d7e-92fcfcf8f428" />



<img width="1372" height="902" alt="Screenshot 2026-01-08 170140" src="https://github.com/user-attachments/assets/ff772558-df8a-4d9b-a3c2-58369860621e" />

---

## ✅ Checklist
Please confirm the following:

- [ X ] My code follows the project’s coding style
- [ X ] I have tested my changes
- [ ] I have updated documentation where necessary
- [ X ] This PR does not introduce breaking changes

---
