### PR TITLE
Fix card layout break caused by malformed alt attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -623,7 +623,7 @@
 
         <div class="card">
             <div class="card-inner">
-                <img src="images\Rudra Agrawal.png" alt=User Photo" class="card-img">
+                <img src="images\Rudra Agrawal.png" alt= "User Photo" class="card-img">
                 <h2>Rudra Agrawal</h2>
                 <span class="role">Full Stack Developer</span>
                 <p>"I am excited to make my first open-source contribution!"</p>


### PR DESCRIPTION
Fixes a missing quote in img alt attribute that caused layout break in production.
Minimal corrective change.
