### PR TITLE
fix: mobile menu background respects active theme

### DIFF
--- a/style.css
+++ b/style.css
@@ -2214,7 +2214,7 @@ html {
         padding: 14px 16px;
         flex-direction: column;
         gap: 6px;
-        background: rgba(30, 41, 59, 0.95);
+        background: var(--glass-bg);
         backdrop-filter: blur(12px);
         -webkit-backdrop-filter: blur(12px);
         border: 1px solid var(--glass-border);


### PR DESCRIPTION
This PR fixes an issue where the mobile navigation menu background remained dark in both light and dark themes.

Previously, the mobile menu used a hardcoded dark background color, which caused incorrect appearance in light mode.
The background has now been updated to use the existing theme-aware CSS variable (--glass-bg), ensuring the menu adapts correctly to the active theme.

Fixes: #644 

### Type of Change
 🐛 Bug fix
  UI / Styling change

### How Has This Been Tested?
Manual testing

### Tested scenarios:

- Mobile menu in light theme
- Mobile menu in dark theme
- Desktop view unaffected

### Screenshot
<img width="438" height="705" alt="image" src="https://github.com/user-attachments/assets/d6670cb8-a00c-4915-bf5c-0f6334ce1ed8" />
