### PR TITLE
Fix FAQ card readability when browser zoom is reduced

### DIFF
--- a/css/faq.css
+++ b/css/faq.css
@@ -555,3 +555,14 @@
         text-transform: uppercase;
         letter-spacing: 0.5px;
     }
+
+    /* Improve FAQ readability on browser zoom out */
+.faq-card {
+  min-width: 280px;
+}
+
+.faq-card p,
+.faq-card li {
+  font-size: 1rem;
+  line-height: 1.6;
+}


### PR DESCRIPTION
This PR improves FAQ card readability when browser zoom is reduced.

- Adds a minimum width to FAQ cards
- Improves text size and line height for better readability
- Enhances accessibility and UX

Fixes #1200 

Screenshot:
![fixed](https://github.com/user-attachments/assets/2b3b5195-419d-4d40-9e20-4db01f5b5395)
