### PR TITLE
Fix: FAQ Page Theme Toggle Not Updating

### DIFF
--- a/css/faq.css
+++ b/css/faq.css
@@ -1,3 +1,14 @@
+    /* Theme support for FAQ page */
+body[data-theme="light"] {
+  background-color: #f9fafb;
+  color: #111827;
+}
+
+body[data-theme="dark"] {
+  background-color: #0f172a;
+  color: #e5e7eb;
+}
+
     /* Premium FAQ Styles */
     * {
         box-sizing: border-box;

--- a/js/faq.js
+++ b/js/faq.js
@@ -138,3 +138,35 @@ document.addEventListener("DOMContentLoaded", function () {
         });
     });
 });
+
+
+document.addEventListener('DOMContentLoaded', function() {
+            const themeToggle = document.getElementById('themeToggle');
+            const body = document.body;
+
+            // Function to set theme
+            function setTheme(theme) {
+                body.setAttribute('data-theme', theme);
+                if (theme === 'light') {
+                    body.classList.add('light-mode');
+                } else {
+                    body.classList.remove('light-mode');
+                }
+                localStorage.setItem('theme', theme);
+                themeToggle.textContent = theme === 'dark' ? '🌙' : '☀️';
+            }
+
+            // Function to toggle theme
+            function toggleTheme() {
+                const currentTheme = body.getAttribute('data-theme') || 'dark';
+                const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+                setTheme(newTheme);
+            }
+
+            // Load saved theme or default to dark
+            const savedTheme = localStorage.getItem('theme') || 'dark';
+            setTheme(savedTheme);
+
+            // Add event listener to theme toggle button
+            themeToggle.addEventListener('click', toggleTheme);
+});


### PR DESCRIPTION
📌 Description

This PR fixes an issue where the FAQ page theme (light/dark mode) did not update correctly when using the theme toggle.
Previously, the FAQ page remained visually static even though the toggle button was clicked.

🛠️ What was changed

1. Added theme support for the FAQ page using data-theme attributes
2. Ensured the theme toggle works consistently on the FAQ page
3. Updated FAQ-specific CSS to respond correctly to light and dark themes
4. Preserved existing styles while enabling theme switching

✅ Expected Behavior

Switching between ☀️ Light Mode and 🌙 Dark Mode updates:
Page background
Text colors
FAQ section appearance

🔍 Testing

Opened faq.html using Live Server
Toggled theme using the navbar button
Verified that background and text colors update correctly
Tested both light and dark modes

📷 Screenshots

Before:
FAQ page background did not change when toggling theme
![before it was light](https://github.com/user-attachments/assets/5e8cfc84-bad0-4db6-a52e-7ecc526cabea)


After:
FAQ page background and text update correctly in both themes
![bright letters and wordings](https://github.com/user-attachments/assets/34916895-8d20-40b4-b151-4e82e4345680)

🔗 Related Issue

Closes: #1194

✔️ Checklist
 Code follows project style guidelines
 Changes tested locally
 No unrelated files modified