### PR TITLE
Add contributor identity and ownership guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,14 @@ Not sure which file to modify? Use the table below to quickly find the right pla
 - Wait for a maintainer to assign the issue to you.
 - This helps avoid duplicate work and conflicts.
 
+## Contributor Identity & Ownership
+
+To maintain the integrity of the community showcase:
+
+- You may only add a profile card for yourself.
+- The GitHub profile linked in your card must match the GitHub account used to open the Pull Request.
+- Editing an existing contributor card is allowed only by the original contributor or project maintainers.
+
 # 🛠 Tech Stack Overview
 Before contributing, it helps to know what we’re working with:
   - HTML5 – Structure and markup for profile cards and layout


### PR DESCRIPTION
This PR adds a clear contributor identity and ownership section to CONTRIBUTING.md.

It defines:
- contributors may only add profile cards for themselves
- the GitHub profile linked must match the PR author
- who is allowed to edit existing contributor cards

This addresses the assigned discussion around trust and integrity
of the contributor showcase.

Happy to iterate based on feedback.