### PR TITLE
Fix: “More” menu redirects instead of opening dropdown

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -131,8 +131,9 @@
     </li>
     <!-- Dropdown -->
     <li class="dropdown">
-      <button class="drop-btn">
-        More ▾</button>
+      <button class="drop-btn" type="button" aria-expanded="false">
+        More ▾
+      </button>
       <ul class="dropdown-menu">
         <li><a href="about.html">About</a></li>
         <li><a href="faq.html">FAQ</a></li>
@@ -395,9 +396,31 @@
       <script>
         lucide.createIcons();
     </script>
+    <script>
+    document.addEventListener("DOMContentLoaded", function () {
+      const dropBtn = document.querySelector(".drop-btn");
+      const dropdown = document.querySelector(".dropdown");
 
+      if (!dropBtn || !dropdown) return;
+
+      dropBtn.addEventListener("click", function (e) {
+        e.preventDefault();
+        dropdown.classList.toggle("active");
+
+        const expanded = dropBtn.getAttribute("aria-expanded") === "true";
+        dropBtn.setAttribute("aria-expanded", String(!expanded));
+      });
+
+      // Close dropdown when clicking outside
+      document.addEventListener("click", function (e) {
+        if (!dropdown.contains(e.target)) {
+          dropdown.classList.remove("active");
+          dropBtn.setAttribute("aria-expanded", "false");
+        }
+      });
+    });
+  </script>
   <script src="./js/faq.js"></script>
   <script src="./js/include.js"></script>
-
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -4045,6 +4045,10 @@ body[data-theme="light"] .toast-message {
   min-width: 180px;
   box-shadow: 0 10px 30px rgba(0,0,0,0.4);
 }
+/* Show dropdown when active */
+.dropdown.active .dropdown-menu {
+  display: block;
+}
 
 .dropdown-menu li {
   padding: 8px 10px;


### PR DESCRIPTION
## 🐞 Issue
Fixes #3073

## What was wrong
The “More” menu in the navbar redirected users to GitHub instead of expanding a dropdown, breaking expected navigation behavior.

## What I fixed
- Removed unintended navigation behavior from the “More” button
- Added a JavaScript toggle to expand/collapse the dropdown
- Enabled dropdown visibility via CSS when active
- Ensured no UI or design changes beyond the reported issue

## Result
Clicking “More” now correctly opens a dropdown menu without redirecting the user.

## Scope
- Frontend only
- Minimal, issue-specific fix

### Screenshots
<img width="1919" height="970" alt="Screenshot 2026-02-11 023258" src="https://github.com/user-attachments/assets/f8de796f-df97-44a6-bf94-02653caf79a3" />


### Closes #3073 
### Program ECWoC'26