### PR TITLE
feat: Add Neural Network Visualizer

### DIFF
--- a/projects/Neural-Network-Visualizer/index.html
+++ b/projects/Neural-Network-Visualizer/index.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Neural Network Visualizer</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>Neural Network Visualizer</h1>
+      <p class="subtitle">Interactive neural network with forward propagation visualization</p>
+    </header>
+
+    <div class="controls">
+      <div class="control-group">
+        <label>Hidden Layers:</label>
+        <select id="hiddenLayers">
+          <option value="1">1</option>
+          <option value="2" selected>2</option>
+          <option value="3">3</option>
+        </select>
+      </div>
+
+      <div class="control-group">
+        <label>Neurons per Layer:</label>
+        <select id="neuronsPerLayer">
+          <option value="2">2</option>
+          <option value="3">3</option>
+          <option value="4" selected>4</option>
+          <option value="5">5</option>
+        </select>
+      </div>
+
+      <div class="control-group">
+        <label>Activation:</label>
+        <select id="activation">
+          <option value="sigmoid">Sigmoid</option>
+          <option value="relu">ReLU</option>
+          <option value="tanh">Tanh</option>
+        </select>
+      </div>
+
+      <button id="rebuildBtn" class="btn">Rebuild Network</button>
+      <button id="randomizeBtn" class="btn">Randomize Weights</button>
+      <button id="stepBtn" class="btn">Step Forward</button>
+      <button id="autoBtn" class="btn">Auto Run</button>
+    </div>
+
+    <div class="main-content">
+      <div class="network-container">
+        <canvas id="networkCanvas"></canvas>
+      </div>
+
+      <div class="info-panel">
+        <div class="info-section">
+          <h3>Input Values</h3>
+          <div id="inputValues" class="values-display"></div>
+          <div class="input-sliders" id="inputSliders"></div>
+        </div>
+
+        <div class="info-section">
+          <h3>Output Layer</h3>
+          <div id="outputValues" class="values-display"></div>
+        </div>
+
+        <div class="info-section">
+          <h3>Network Info</h3>
+          <div id="networkInfo">
+            <p><strong>Total Layers:</strong> <span id="totalLayers">4</span></p>
+            <p><strong>Total Weights:</strong> <span id="totalWeights">0</span></p>
+            <p><strong>Current Step:</strong> <span id="currentStep">0</span></p>
+          </div>
+        </div>
+
+        <div class="info-section">
+          <h3>How to Use</h3>
+          <ul>
+            <li>Click on neurons to select</li>
+            <li>Click on connections to edit weights</li>
+            <li>Use sliders to change input values</li>
+            <li>Watch activations propagate forward</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <div class="weight-editor" id="weightEditor" style="display: none;">
+      <h3>Edit Connection Weight</h3>
+      <label>Weight Value:</label>
+      <input type="number" id="weightInput" step="0.1" value="0">
+      <button id="applyWeightBtn" class="btn">Apply</button>
+      <button id="cancelWeightBtn" class="btn">Cancel</button>
+    </div>
+  </div>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/projects/Neural-Network-Visualizer/script.js
+++ b/projects/Neural-Network-Visualizer/script.js
@@ -1,0 +1,400 @@
+class NeuralNetworkVisualizer {
+  constructor() {
+    this.canvas = document.getElementById('networkCanvas');
+    this.ctx = this.canvas.getContext('2d');
+    this.layers = [];
+    this.weights = [];
+    this.biases = [];
+    this.activations = [];
+    this.selectedConnection = null;
+    this.animationStep = 0;
+    this.isAnimating = false;
+    this.autoRunInterval = null;
+
+    this.setupCanvas();
+    this.setupControls();
+    this.buildNetwork();
+    this.setupEventListeners();
+  }
+
+  setupCanvas() {
+    const container = this.canvas.parentElement;
+    this.canvas.width = container.clientWidth - 40;
+    this.canvas.height = Math.max(500, container.clientHeight - 40);
+  }
+
+  setupControls() {
+    this.hiddenLayersSelect = document.getElementById('hiddenLayers');
+    this.neuronsPerLayerSelect = document.getElementById('neuronsPerLayer');
+    this.activationSelect = document.getElementById('activation');
+    this.rebuildBtn = document.getElementById('rebuildBtn');
+    this.randomizeBtn = document.getElementById('randomizeBtn');
+    this.stepBtn = document.getElementById('stepBtn');
+    this.autoBtn = document.getElementById('autoBtn');
+  }
+
+  setupEventListeners() {
+    window.addEventListener('resize', () => {
+      this.setupCanvas();
+      this.draw();
+    });
+
+    this.rebuildBtn.addEventListener('click', () => this.buildNetwork());
+    this.randomizeBtn.addEventListener('click', () => this.randomizeWeights());
+    this.stepBtn.addEventListener('click', () => this.stepForward());
+    this.autoBtn.addEventListener('click', () => this.toggleAutoRun());
+
+    this.canvas.addEventListener('click', (e) => this.handleCanvasClick(e));
+  }
+
+  buildNetwork() {
+    const hiddenLayers = parseInt(this.hiddenLayersSelect.value);
+    const neuronsPerLayer = parseInt(this.neuronsPerLayerSelect.value);
+
+    this.layers = [2];
+    for (let i = 0; i < hiddenLayers; i++) {
+      this.layers.push(neuronsPerLayer);
+    }
+    this.layers.push(1);
+
+    this.weights = [];
+    this.biases = [];
+    this.activations = [];
+
+    for (let i = 0; i < this.layers.length; i++) {
+      this.activations.push(new Array(this.layers[i]).fill(0));
+    }
+
+    for (let i = 0; i < this.layers.length - 1; i++) {
+      const layerWeights = [];
+      for (let j = 0; j < this.layers[i]; j++) {
+        const neuronWeights = [];
+        for (let k = 0; k < this.layers[i + 1]; k++) {
+          neuronWeights.push((Math.random() * 2 - 1).toFixed(2));
+        }
+        layerWeights.push(neuronWeights);
+      }
+      this.weights.push(layerWeights);
+    }
+
+    for (let i = 1; i < this.layers.length; i++) {
+      this.biases.push(new Array(this.layers[i]).fill(0).map(() => (Math.random() * 2 - 1).toFixed(2)));
+    }
+
+    this.animationStep = 0;
+    this.updateNetworkInfo();
+    this.setupInputSliders();
+    this.draw();
+  }
+
+  randomizeWeights() {
+    for (let i = 0; i < this.weights.length; i++) {
+      for (let j = 0; j < this.weights[i].length; j++) {
+        for (let k = 0; k < this.weights[i][j].length; k++) {
+          this.weights[i][j][k] = (Math.random() * 2 - 1).toFixed(2);
+        }
+      }
+    }
+
+    for (let i = 0; i < this.biases.length; i++) {
+      for (let j = 0; j < this.biases[i].length; j++) {
+        this.biases[i][j] = (Math.random() * 2 - 1).toFixed(2);
+      }
+    }
+
+    this.animationStep = 0;
+    this.draw();
+  }
+
+  setupInputSliders() {
+    const container = document.getElementById('inputSliders');
+    container.innerHTML = '';
+
+    for (let i = 0; i < this.layers[0]; i++) {
+      const group = document.createElement('div');
+      group.className = 'slider-group';
+
+      const label = document.createElement('label');
+      label.textContent = `Input ${i + 1}:`;
+
+      const slider = document.createElement('input');
+      slider.type = 'range';
+      slider.min = '0';
+      slider.max = '1';
+      slider.step = '0.01';
+      slider.value = '0.5';
+
+      slider.addEventListener('input', () => {
+        this.activations[0][i] = parseFloat(slider.value);
+        this.animationStep = 0;
+        this.draw();
+      });
+
+      group.appendChild(label);
+      group.appendChild(slider);
+      container.appendChild(group);
+
+      this.activations[0][i] = 0.5;
+    }
+
+    this.draw();
+  }
+
+  getActivationFunction(x) {
+    const func = this.activationSelect.value;
+    switch (func) {
+      case 'sigmoid':
+        return 1 / (1 + Math.exp(-x));
+      case 'relu':
+        return Math.max(0, x);
+      case 'tanh':
+        return Math.tanh(x);
+      default:
+        return 1 / (1 + Math.exp(-x));
+    }
+  }
+
+  getActivationDerivative(x) {
+    const func = this.activationSelect.value;
+    const sigmoid = 1 / (1 + Math.exp(-x));
+    switch (func) {
+      case 'sigmoid':
+        return sigmoid * (1 - sigmoid);
+      case 'relu':
+        return x > 0 ? 1 : 0;
+      case 'tanh':
+        return 1 - Math.pow(Math.tanh(x), 2);
+      default:
+        return sigmoid * (1 - sigmoid);
+    }
+  }
+
+  stepForward() {
+    if (this.animationStep >= this.layers.length - 1) {
+      this.animationStep = 0;
+    }
+
+    const targetLayer = this.animationStep + 1;
+
+    for (let j = 0; j < this.layers[targetLayer]; j++) {
+      let sum = this.biases[targetLayer - 1][j];
+      for (let i = 0; i < this.layers[targetLayer - 1]; i++) {
+        sum += parseFloat(this.activations[targetLayer - 1][i]) *
+                parseFloat(this.weights[targetLayer - 1][i][j]);
+      }
+      this.activations[targetLayer][j] = this.getActivationFunction(sum);
+    }
+
+    this.animationStep++;
+    this.updateNetworkInfo();
+    this.draw();
+  }
+
+  toggleAutoRun() {
+    if (this.autoRunInterval) {
+      clearInterval(this.autoRunInterval);
+      this.autoRunInterval = null;
+      this.autoBtn.textContent = 'Auto Run';
+    } else {
+      this.autoRunInterval = setInterval(() => {
+        if (this.animationStep >= this.layers.length - 1) {
+          this.animationStep = 0;
+        }
+        this.stepForward();
+      }, 800);
+      this.autoBtn.textContent = 'Stop';
+    }
+  }
+
+  draw() {
+    this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+
+    const layerSpacing = this.canvas.width / (this.layers.length + 1);
+    const neuronPositions = [];
+
+    for (let i = 0; i < this.layers.length; i++) {
+      const x = layerSpacing * (i + 1);
+      neuronPositions[i] = [];
+
+      const neuronSpacing = this.canvas.height / (this.layers[i] + 1);
+
+      for (let j = 0; j < this.layers[i]; j++) {
+        const y = neuronSpacing * (j + 1);
+        neuronPositions[i].push({ x, y });
+
+        const activation = this.activations[i][j];
+        const isActivated = i <= this.animationStep;
+
+        for (let prevI = 0; prevI < i; prevI++) {
+          for (let prevJ = 0; prevJ < this.layers[prevI]; prevJ++) {
+            const prevX = neuronPositions[prevI][prevJ].x;
+            const prevY = neuronPositions[prevI][prevJ].y;
+
+            const weight = this.weights[prevI][prevJ][j];
+            const isConnectionActive = prevI < this.animationStep;
+
+            this.ctx.beginPath();
+            this.ctx.moveTo(prevX, prevY);
+            this.ctx.lineTo(x, y);
+
+            if (isConnectionActive) {
+              const gradient = this.ctx.createLinearGradient(prevX, prevY, x, y);
+              if (weight >= 0) {
+                gradient.addColorStop(0, `rgba(0, 217, 255, ${Math.min(1, Math.abs(weight))})`);
+                gradient.addColorStop(1, `rgba(0, 255, 136, ${Math.min(1, Math.abs(weight))})`);
+              } else {
+                gradient.addColorStop(0, `rgba(255, 100, 100, ${Math.min(1, Math.abs(weight))})`);
+                gradient.addColorStop(1, `rgba(255, 150, 50, ${Math.min(1, Math.abs(weight))})`);
+              }
+              this.ctx.strokeStyle = gradient;
+              this.ctx.lineWidth = Math.abs(weight) * 3 + 1;
+            } else {
+              this.ctx.strokeStyle = 'rgba(100, 100, 100, 0.3)';
+              this.ctx.lineWidth = 1;
+            }
+
+            this.ctx.stroke();
+          }
+        }
+      }
+    }
+
+    for (let i = 0; i < this.layers.length; i++) {
+      for (let j = 0; j < this.layers[i]; j++) {
+        const pos = neuronPositions[i][j];
+        const activation = this.activations[i][j];
+        const isActivated = i <= this.animationStep;
+
+        const radius = 20;
+
+        const gradient = this.ctx.createRadialGradient(pos.x, pos.y, 0, pos.x, pos.y, radius);
+        if (isActivated) {
+          const intensity = Math.min(1, Math.abs(activation));
+          gradient.addColorStop(0, `rgba(0, 217, 255, ${intensity})`);
+          gradient.addColorStop(0.5, `rgba(0, 150, 255, ${intensity * 0.8})`);
+          gradient.addColorStop(1, `rgba(0, 100, 200, ${intensity * 0.6})`);
+        } else {
+          gradient.addColorStop(0, 'rgba(100, 100, 100, 0.5)');
+          gradient.addColorStop(1, 'rgba(50, 50, 50, 0.3)');
+        }
+
+        this.ctx.beginPath();
+        this.ctx.arc(pos.x, pos.y, radius, 0, Math.PI * 2);
+        this.ctx.fillStyle = gradient;
+        this.ctx.fill();
+
+        this.ctx.strokeStyle = isActivated ? '#00d9ff' : '#444';
+        this.ctx.lineWidth = 2;
+        this.ctx.stroke();
+
+        this.ctx.fillStyle = '#fff';
+        this.ctx.font = '12px Arial';
+        this.ctx.textAlign = 'center';
+        this.ctx.textBaseline = 'middle';
+        this.ctx.fillText(activation.toFixed(2), pos.x, pos.y);
+
+        if (i === 0) {
+          this.ctx.fillStyle = '#aaa';
+          this.ctx.font = '10px Arial';
+          this.ctx.fillText(`I${j + 1}`, pos.x, pos.y - radius - 5);
+        } else if (i === this.layers.length - 1) {
+          this.ctx.fillStyle = '#aaa';
+          this.ctx.font = '10px Arial';
+          this.ctx.fillText(`O`, pos.x, pos.y - radius - 5);
+        }
+      }
+    }
+
+    this.updateValuesDisplay();
+  }
+
+  updateValuesDisplay() {
+    const inputContainer = document.getElementById('inputValues');
+    const outputContainer = document.getElementById('outputValues');
+
+    inputContainer.innerHTML = this.activations[0]
+      .map((val, i) => `<span class="value-tag">I${i + 1}: ${val.toFixed(2)}</span>`)
+      .join('');
+
+    const lastLayer = this.layers.length - 1;
+    outputContainer.innerHTML = this.activations[lastLayer]
+      .map((val, i) => `<span class="value-tag">Output: ${val.toFixed(2)}</span>`)
+      .join('');
+  }
+
+  updateNetworkInfo() {
+    document.getElementById('totalLayers').textContent = this.layers.length;
+
+    let totalWeights = 0;
+    for (let i = 0; i < this.weights.length; i++) {
+      for (let j = 0; j < this.weights[i].length; j++) {
+        totalWeights += this.weights[i][j].length;
+      }
+    }
+    document.getElementById('totalWeights').textContent = totalWeights;
+    document.getElementById('currentStep').textContent = this.animationStep;
+  }
+
+  handleCanvasClick(e) {
+    const rect = this.canvas.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+
+    const layerSpacing = this.canvas.width / (this.layers.length + 1);
+
+    for (let i = 0; i < this.layers.length - 1; i++) {
+      const neuronSpacing = this.canvas.height / (this.layers[i] + 1);
+
+      for (let j = 0; j < this.layers[i]; j++) {
+        const neuronX = layerSpacing * (i + 1);
+        const neuronY = neuronSpacing * (j + 1);
+
+        const nextLayerSpacing = this.canvas.height / (this.layers[i + 1] + 1);
+
+        for (let k = 0; k < this.layers[i + 1]; k++) {
+          const nextX = layerSpacing * (i + 2);
+          const nextY = nextLayerSpacing * (k + 1);
+
+          const midX = (neuronX + nextX) / 2;
+          const midY = (neuronY + nextY) / 2;
+
+          const distance = Math.sqrt((x - midX) ** 2 + (y - midY) ** 2);
+
+          if (distance < 10) {
+            this.showWeightEditor(i, j, k, this.weights[i][j][k]);
+            return;
+          }
+        }
+      }
+    }
+  }
+
+  showWeightEditor(layer, from, to, currentValue) {
+    this.selectedConnection = { layer, from, to };
+    const editor = document.getElementById('weightEditor');
+    const input = document.getElementById('weightInput');
+    input.value = currentValue;
+    editor.style.display = 'block';
+
+    document.getElementById('applyWeightBtn').onclick = () => {
+      const newValue = parseFloat(input.value);
+      if (!isNaN(newValue)) {
+        this.weights[this.selectedConnection.layer]
+                     [this.selectedConnection.from]
+                     [this.selectedConnection.to] = newValue.toFixed(2);
+        this.draw();
+      }
+      editor.style.display = 'none';
+      this.selectedConnection = null;
+    };
+
+    document.getElementById('cancelWeightBtn').onclick = () => {
+      editor.style.display = 'none';
+      this.selectedConnection = null;
+    };
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  new NeuralNetworkVisualizer();
+});

--- a/projects/Neural-Network-Visualizer/style.css
+++ b/projects/Neural-Network-Visualizer/style.css
@@ -1,0 +1,246 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background: linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%);
+  color: #eee;
+  min-height: 100vh;
+}
+
+.container {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+header {
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+header h1 {
+  font-size: 2.5rem;
+  background: linear-gradient(45deg, #00d9ff, #00ff88);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 5px;
+}
+
+.subtitle {
+  color: #888;
+  font-size: 1rem;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 15px;
+  justify-content: center;
+  align-items: center;
+  background: rgba(255, 255, 255, 0.05);
+  padding: 20px;
+  border-radius: 10px;
+  margin-bottom: 20px;
+  backdrop-filter: blur(10px);
+}
+
+.control-group {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.control-group label {
+  font-size: 0.9rem;
+  color: #aaa;
+}
+
+.control-group select {
+  padding: 8px 12px;
+  border-radius: 5px;
+  border: 1px solid #444;
+  background: #2a2a4a;
+  color: #fff;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.btn {
+  padding: 10px 20px;
+  border: none;
+  border-radius: 5px;
+  background: linear-gradient(45deg, #00d9ff, #00ff88);
+  color: #000;
+  font-weight: bold;
+  cursor: pointer;
+  transition: transform 0.2s, box-shadow 0.2s;
+  font-size: 0.9rem;
+}
+
+.btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 5px 20px rgba(0, 217, 255, 0.4);
+}
+
+.btn:active {
+  transform: translateY(0);
+}
+
+.main-content {
+  display: grid;
+  grid-template-columns: 1fr 350px;
+  gap: 20px;
+}
+
+.network-container {
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 10px;
+  padding: 20px;
+  min-height: 500px;
+}
+
+#networkCanvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.info-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+
+.info-section {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 10px;
+  padding: 15px;
+}
+
+.info-section h3 {
+  margin-bottom: 10px;
+  font-size: 1.1rem;
+  color: #00d9ff;
+}
+
+.values-display {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.value-tag {
+  background: rgba(0, 217, 255, 0.2);
+  padding: 5px 10px;
+  border-radius: 5px;
+  font-size: 0.85rem;
+  font-family: 'Courier New', monospace;
+}
+
+.input-sliders {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.slider-group {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.slider-group label {
+  font-size: 0.85rem;
+  color: #aaa;
+  min-width: 60px;
+}
+
+.slider-group input[type="range"] {
+  flex: 1;
+  accent-color: #00d9ff;
+}
+
+#networkInfo p {
+  margin: 5px 0;
+  font-size: 0.9rem;
+  color: #aaa;
+}
+
+#networkInfo strong {
+  color: #00ff88;
+}
+
+.info-section ul {
+  list-style: none;
+  padding: 0;
+}
+
+.info-section li {
+  padding: 5px 0;
+  font-size: 0.85rem;
+  color: #aaa;
+  position: relative;
+  padding-left: 20px;
+}
+
+.info-section li:before {
+  content: "> ";
+  position: absolute;
+  left: 0;
+  color: #00d9ff;
+}
+
+.weight-editor {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: #1a1a2e;
+  border: 1px solid #00d9ff;
+  border-radius: 10px;
+  padding: 20px;
+  z-index: 1000;
+  box-shadow: 0 10px 50px rgba(0, 0, 0, 0.5);
+}
+
+.weight-editor h3 {
+  margin-bottom: 15px;
+  color: #00d9ff;
+}
+
+.weight-editor label {
+  display: block;
+  margin-bottom: 10px;
+  color: #aaa;
+}
+
+.weight-editor input[type="number"] {
+  width: 100%;
+  padding: 10px;
+  border-radius: 5px;
+  border: 1px solid #444;
+  background: #2a2a4a;
+  color: #fff;
+  font-size: 1rem;
+  margin-bottom: 15px;
+}
+
+.weight-editor .btn {
+  margin-right: 10px;
+}
+
+@media (max-width: 900px) {
+  .main-content {
+    grid-template-columns: 1fr;
+  }
+
+  header h1 {
+    font-size: 1.8rem;
+  }
+}


### PR DESCRIPTION
## Summary

Implements a neural network visualizer as requested in issue #3365

- Draw neural network with configurable architecture
- Forward propagate values visually with animation
- Animate activations through the network layers
- Allow users to change weights via interactive click-to-edit
- Show activation values in real-time
- Support sigmoid, ReLU, and tanh activation functions
- Interactive input sliders for real-time value changes
- Step-by-step and auto-run propagation modes

## Implementation

Uses vanilla HTML, CSS, and JavaScript with no external libraries as specified in the issue.

The visualizer provides:
- Canvas-based rendering of neural network architecture
- Real-time forward propagation visualization
- Weight editing through click interaction
- Multiple activation functions
- Configurable network topology

## Testing

Tested locally with:
- Varying numbers of hidden layers (1-3)
- Varying neurons per layer (2-5)
- All activation functions (sigmoid, ReLU, tanh)
- Weight editing functionality
- Auto-run and step-by-step modes

Closes #3365