### PR TITLE
Add logging utility and enhance ESLint rules to prevent console.log

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,32 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true,
+    "node": true,
+    "jest": true
+  },
+  "extends": "eslint:recommended",
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "rules": {
+    "no-console": ["error", { "allow": ["warn", "error"] }],
+    "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
+    "no-undef": "error",
+    "no-empty-function": "warn",
+    "no-eval": "error",
+    "no-implied-eval": "error",
+    "prefer-const": "warn",
+    "no-var": "error",
+    "eqeqeq": ["error", "always"],
+    "curly": ["error", "multi-line"]
+  },
+  "globals": {
+    "filterCards": "readonly",
+    "filterByRole": "readonly",
+    "sortCards": "readonly",
+    "lucide": "readonly",
+    "Logger": "readonly"
+  }
+}

--- a/js/logger.js
+++ b/js/logger.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const Logger = {
+    isDevelopment: function() {
+        return window.location.hostname === 'localhost' || 
+               window.location.hostname === '127.0.0.1' ||
+               window.location.hostname.includes('dev.');
+    },
+
+    debug: function(message, ...args) {
+        if (this.isDevelopment()) {
+            console.log('[DEBUG]', message, ...args);
+        }
+    },
+
+    info: function(message, ...args) {
+        if (this.isDevelopment()) {
+            console.info('[INFO]', message, ...args);
+        }
+    },
+
+    warn: function(message, ...args) {
+        console.warn('[WARN]', message, ...args);
+    },
+
+    error: function(message, ...args) {
+        console.error('[ERROR]', message, ...args);
+    },
+
+    group: function(label) {
+        if (this.isDevelopment()) {
+            console.group(label);
+        }
+    },
+
+    groupEnd: function() {
+        if (this.isDevelopment()) {
+            console.groupEnd();
+        }
+    },
+
+    time: function(label) {
+        if (this.isDevelopment()) {
+            console.time(label);
+        }
+    },
+
+    timeEnd: function(label) {
+        if (this.isDevelopment()) {
+            console.timeEnd(label);
+        }
+    }
+};
+
+if (typeof window !== 'undefined') {
+    window.Logger = Logger;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = Logger;
+}


### PR DESCRIPTION
## Summary

Fixes #4555

This PR adds a development-friendly logging utility and enhances ESLint rules to prevent console.log statements in production code.

## Changes Made

### Logger Utility (`js/logger.js`)
A new utility module that provides environment-aware logging:
- `Logger.debug()` - Only logs in development environment
- `Logger.info()` - Only logs in development environment
- `Logger.warn()` - Always logs (acceptable for production)
- `Logger.error()` - Always logs (needed for error tracking)
- `Logger.group()`, `Logger.groupEnd()` - Grouping for development
- `Logger.time()`, `Logger.timeEnd()` - Performance timing for development

### Development Detection
The logger automatically detects development environment based on:
- localhost
- 127.0.0.1
- Hostnames containing 'dev.'

### ESLint Configuration (`.eslintrc.json`)
Updated rules:
- `no-console: ["error", { "allow": ["warn", "error"] }]` - Prevents console.log but allows warn/error
- Added `Logger` to global variables

## Current State
The main JavaScript files (`js/analytics.js`, `js/statistics.js`, `js/include.js`, `projects.js`, etc.) already use `console.error` and `console.warn` appropriately for error handling, which is acceptable for production.

## Usage Example
```javascript
// Instead of:
console.log('User logged in', user);

// Use:
Logger.debug('User logged in', user); // Only logs in development
Logger.error('Failed to fetch data:', error); // Always logs
```

## Benefits
- Cleaner console for end users
- Environment-aware debugging
- Consistent logging format with prefixes
- ESLint prevents accidental console.log additions
- Error tracking still works in production