### PR TITLE
Fix: Remove duplicate nested main and card-container elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,6 @@
 </head>
 
 <body>
-    <main>
     <a href="#main-content" class="skip-link">Skip to main content</a>
 
     <div class="circle-container">
@@ -1080,7 +1079,6 @@
             </div>
         </div>
         
-</div>
 </main>
 <style>
     /* Ensure footer stays at bottom */
@@ -1112,13 +1110,11 @@ main {
 
 </style>
  
-</main>
        <div id="footer"></div>
 
    
         <!-- ADD YOUR NEW CARD ABOVE THIS COMMENT -->
 
-    </main> <!-- End of card-container -->
 
  
     <!--<script src="tilt.js"></script>-->


### PR DESCRIPTION
## Description

Removes duplicate container elements in `index.html` where three container opening tags were declared consecutively for the contributor cards section. Two `<main>` elements sharing the same `id="main-content"` are forbidden by the HTML specification. Nested `<main>` elements are also invalid.

This fix retains a single `<main id="main-content" class="card-container" role="main">` and removes the redundant outer `<main>` opening tag along with the three orphaned closing tags that resulted from the duplicate and extra container openings.

Fixes: #4817

---

## Type of Change

- [x] Bug fix

---

## How Has This Been Tested?

- [x] Manual testing
- Verified a single `<main id="main-content">` element exists in the document
- Confirmed the skip-link `<a href="#main-content">` resolves correctly
- Validated HTML structure via browser DevTools

---

## Screenshots Checklist (Mandatory)

The fix corrects invalid HTML structure with no visual change to the rendered page.

---

## Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes
- [x] I have updated documentation where necessary
- [x] This PR does not introduce breaking changes

---

## Additional Notes

Only the duplicate opening tag and orphaned closing tags were removed. The card grid content and the single valid closing tag were left unchanged.