### PR TITLE
Fix: Add rel=noopener noreferrer to all target=_blank anchor elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
     </li>
 
     <li>
-      <a href="https://github.com/Jayanta2004/dev-card-showcase" target="_blank">
+      <a href="https://github.com/Jayanta2004/dev-card-showcase" target="_blank" rel="noopener noreferrer">
         GitHub
       </a>
     </li>
@@ -265,7 +265,7 @@
                 <h2>Project Admin</h2>
                 <span class="role">Maintainer</span>
                 <p>"Welcome to the project! Fork this repo and add your card below."</p>
-                <a href="https://github.com/Jayanta2004" class="card-btn" target="_blank" rel="noopener" aria-label="View Project Admin's GitHub profile">GitHub</a>
+                <a href="https://github.com/Jayanta2004" class="card-btn" target="_blank" rel="noopener noreferrer" aria-label="View Project Admin's GitHub profile">GitHub</a>
             </div>
         </div>
 
@@ -277,7 +277,7 @@
                 <h2>Contributor Name</h2>
                 <span class="role">Developer</span>
                 <p>"I learned how to make a Pull Request today!"</p>
-                <a href="#" class="card-btn" target="_blank" aria-label="View Contributor Name's GitHub profile">View Profile</a>
+                <a href="#" class="card-btn" target="_blank" rel="noopener noreferrer" aria-label="View Contributor Name's GitHub profile">View Profile</a>
             </div>
         </div>
         <!-- 👆 CONTRIBUTORS: END COPYING HERE 👆 -->
@@ -289,7 +289,7 @@
                 <h2>Chirag Tankan</h2>
                 <span class="role">Developer</span>
                 <p>"Professional Contributor"</p>
-                <a href="http://github.com/ChiragTankan/" class="card-btn" target="_blank">View Profile</a>
+                <a href="http://github.com/ChiragTankan/" class="card-btn" target="_blank" rel="noopener noreferrer">View Profile</a>
             </div>
         </div>
         
@@ -299,7 +299,7 @@
                 <h2>Mohit Yadav</h2>
                 <span class="role">Frontend Wizard</span>
                 <p>"Hello world! This is my first PR."</p>
-                <a href="https://github.com/19-mohityadav" class="card-btn" target="_blank">GitHub</a>
+                <a href="https://github.com/19-mohityadav" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
             </div>
         </div>
 
@@ -309,7 +309,7 @@
                 <h2>Sameer Baral</h2>
                 <span class="role">Developer</span>
                 <p>"This is my first Pull Request"</p>
-                <a href="https://github.com/SameerBaral" class="card-btn" target="_blank">GitHub</a>
+                <a href="https://github.com/SameerBaral" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
             </div>
         </div>
 
@@ -319,7 +319,7 @@
                 <h2>Manas Sharma</h2>
                 <span class="role">Contributor</span>
                 <p>"My first open-source contribution through ECWoC!"</p>
-                <a href="https://github.com/ManasCodez" class="card-btn" target="_blank">GitHub</a>
+                <a href="https://github.com/ManasCodez" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
             </div>
         </div>
 
@@ -329,7 +329,7 @@
             <h2>Shreya Kumari</h2>
             <span class="role">Contributor</span>
             <p>"Hello, This is my first Pull Request!"</p>
-            <a href="https://github.com/Shreyyyi" class="card-btn" target="_blank">GitHub</a>
+            <a href="https://github.com/Shreyyyi" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
         
             </div>
         </div>
@@ -340,7 +340,7 @@
             <h2>Sakshi Tamshetti</h2>
             <span class="role">Contributor</span>
             <p>"Hey, just made my first contribution via ECWoc - looking forward to the journey!"</p>
-            <a href="https://github.com/SakshiTamshetti" class="card-btn" target="_blank">GitHub</a>
+            <a href="https://github.com/SakshiTamshetti" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
         
             </div>
         </div>
@@ -351,7 +351,7 @@
             <h2>Muskan</h2>
             <span class="role">Contributor</span>
             <p>"Hello, This is my first open-source contribution through ECWoC!"</p>
-            <a href="https://github.com/squirrelk6755-ctrl" class="card-btn" target="_blank">GitHub</a>
+            <a href="https://github.com/squirrelk6755-ctrl" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
         
             </div>
         </div>
@@ -362,7 +362,7 @@
             <h2>Himanshu</h2>
             <span class="role">Contributor</span>
             <p>"Excited to contribute to open source via ECWoC 2026 🚀"</p>
-            <a href="https://github.com/bugVixen-M" class="card-btn" target="_blank">GitHub</a>
+            <a href="https://github.com/bugVixen-M" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
         
             </div>
         </div>
@@ -372,7 +372,7 @@
                 <h2>CodeMaster11000</h2>
                 <span class="role">Contributor</span>
                 <p>"A simple CSE student who is learning to code and contribute to open source"</p>
-                <a href="https://github.com/CodeMaster11000" class="card-btn" target="_blank">GitHub</a>
+                <a href="https://github.com/CodeMaster11000" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
             </div>
         </div>
 
@@ -382,7 +382,7 @@
                 <h2>Omkar Hole</h2>
                 <span class="role">Contributor</span>
                 <p>"Starting my open-source journey with ECWoC 🚀"</p>
-                <a href="https://github.com/omkarhole" class="card-btn" target="_blank">GitHub</a>
+                <a href="https://github.com/omkarhole" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
             </div>
         </div>
 
@@ -392,7 +392,7 @@
             <h2>Sunetra Bar</h2>
             <span class="role">Contributor</span>
             <p>"Hey, just made my first contribution via ECWoc - looking forward to the journey!"</p>
-            <a href="https://github.com/Bar-7150" class="card-btn" target="_blank">GitHub</a>
+            <a href="https://github.com/Bar-7150" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
         
             </div>
         </div>
@@ -403,7 +403,7 @@
             <h2>Alen Alexander</h2>
             <span class="role">Contributor</span>
             <p>"Happy to make my first open-source contribution!"</p>
-            <a href="https://github.com/alenalex-009" class="card-btn" target="_blank">GitHub</a>
+            <a href="https://github.com/alenalex-009" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
         
             </div>
         </div>
@@ -414,7 +414,7 @@
             <h2>YASH PATIL</h2>
             <span class="role">Contributor</span>
             <p>"CS student exploring Open Source. Happy to make my first PR!"</p>
-            <a href="https://github.com/yash12991" class="card-btn" target="_blank">GitHub</a>
+            <a href="https://github.com/yash12991" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
         
             </div>
         </div>
@@ -425,7 +425,7 @@
             <h2>Pranav Agarwal</h2>
             <span class="role">Frontend Developer</span>
             <p>"Starting my open-source journey with ECWoC 🚀"</p>
-            <a href="https://github.com/agarwalpranav0711" class="card-btn" target="_blank">GitHub</a>
+            <a href="https://github.com/agarwalpranav0711" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
         
             </div>
         </div>
@@ -436,7 +436,7 @@
             <h2>Neeru</h2>
             <span class="role">Open Source Contributor</span>
             <p>"CSE student passionate about exploring and contributing to Open Source projects."</p>
-            <a href="https://github.com/neeru24" class="card-btn" target="_blank">GitHub</a>
+            <a href="https://github.com/neeru24" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
         
             </div>
         </div>
@@ -448,7 +448,7 @@
             <span class="role">Contributor</span>
             <p>Hi! This is my first open-source contribution through ECWoC. Looking forward to contributing more and
                 learning along the way.</p>
-            <a href="https://github.com/Prithwish2025" class="card-btn" target="_blank">Github</a>
+            <a href="https://github.com/Prithwish2025" class="card-btn" target="_blank" rel="noopener noreferrer">Github</a>
         
             </div>
         </div>
@@ -459,7 +459,7 @@
             <h2>Abhijeet Padhy</h2>
             <span class="role">Open Source Contributor</span>
             <p>"Excited to contribute to open source🚀"</p>
-            <a href="https://github.com/Abhijeet-980" class="card-btn" target="_blank">GitHub</a>
+            <a href="https://github.com/Abhijeet-980" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
         
             </div>
         </div>
@@ -471,7 +471,7 @@
             <span class="role">Developer</span>
             <p>"Coding is not just skill, it's an art of representing ideas into reality"</p>
             <a href="https://www.linkedin.com/in/anand-kumar-patel-ba9607371/" class="card-btn"
-                target="_blank">Linkedin</a>
+                target="_blank" rel="noopener noreferrer">Linkedin</a>
         
             </div>
         </div>
@@ -482,7 +482,7 @@
             <h2>Satyam Pandey</h2>
             <span class="role">Contributor</span>
             <p>"Hello world! This is my first PR."</p>
-            <a href="https://github.com/satyam-pandey" class="card-btn" target="_blank">GitHub</a>
+            <a href="https://github.com/satyam-pandey" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
         
             </div>
         </div>
@@ -493,7 +493,7 @@
             <h2>Rohit Shinde</h2>
             <span class="role">Contributor</span>
             <p>"Exploring open source and learning GitHub through my first contribution."</p>
-            <a href="https://github.com/rohitshinde-tech" class="card-btn" target="_blank">GitHub</a>
+            <a href="https://github.com/rohitshinde-tech" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
         
             </div>
         </div>
@@ -504,7 +504,7 @@
             <span class="role">Contributor</span>
             <p>"IT student passionate about Open Source, constantly exploring new technologies and contributing to
                 meaningful projects."</p>
-            <a href="https://github.com/Snehasish-tech" class="card-btn" target="_blank">GitHub</a>
+            <a href="https://github.com/Snehasish-tech" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
         
             </div>
         </div>
@@ -515,7 +515,7 @@
             <h2>Mayank Vyas</h2>
             <span class="role">Contributor</span>
             <p>"My journey in open source started with courage, not perfection"</p>
-            <a href="https://github.com/mayankvya" class="card-btn" target="_blank">GitHub</a>
+            <a href="https://github.com/mayankvya" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
         
             </div>
         </div>
@@ -526,7 +526,7 @@
             <h2>Ashish Kumar</h2>
             <span class="role">Contributor</span>
             <p>Hey, this is my first contribution to ECWoC!</p>
-            <a href="https://github.com/whoashish115" class="card-btn" target="_blank">GitHub</a>
+            <a href="https://github.com/whoashish115" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
         
             </div>
         </div>
@@ -537,7 +537,7 @@
             <h2>Arpan Purkait</h2>
             <span class="role">Django Developer</span>
             <p>Zindegi Ek safar hai.....</p>
-            <a href="https://github.com/arpanpurkait" class="card-btn" target="_blank">GitHub</a>
+            <a href="https://github.com/arpanpurkait" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
         
             </div>
         </div>
@@ -549,7 +549,7 @@
             <span class="role">Contributor</span>
             <p>"Radhe Radhe!! This is my first Open-source Contribution , I'm really excited to be part of this
                 community"</p>
-            <a href="https://github.com/roychowdhury-arghya" class="card-btn" target="_blank">GitHub</a>
+            <a href="https://github.com/roychowdhury-arghya" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
         
             </div>
         </div>
@@ -560,7 +560,7 @@
             <h2>Amballa Sneha</h2>
             <span class="role">Developer</span>
             <p>"This is 1st PR in EWOC'26 "</p>
-            <a href="https://github.com/Sneha-Amballa" class="card-btn" target="_blank">View Profile</a>
+            <a href="https://github.com/Sneha-Amballa" class="card-btn" target="_blank" rel="noopener noreferrer">View Profile</a>
         
             </div>
         </div>
@@ -571,7 +571,7 @@
                 <h2>Dupati Sanjay Kumar</h2>
                 <span class="role">Developer</span>
                 <p>"I'm about to start contributing to open source communities from today!!"</p>
-                <a href="https://github.com/Sanju562586" class="card-btn" target="_blank">GitHub</a>
+                <a href="https://github.com/Sanju562586" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
             </div>
         </div>
 
@@ -581,7 +581,7 @@
             <h2>Krishna Kumar</h2>
             <span class="role">Contributor</span>
             <p>"Excited to make my first open-source contribution through ECWoC 2026"</p>
-            <a href="https://github.com/krishnx21" class="card-btn" target="_blank">GitHub</a>
+            <a href="https://github.com/krishnx21" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
         
             </div>
         </div>
@@ -592,7 +592,7 @@
             <h2>Aditya Jain</h2>
             <span class="role">Contributor</span>
             <p>"This is my first open-source contribution through ECWoC thanks for this opportunity very much!"</p>
-            <a href="https://github.com/aditya2006magic" class="card-btn" target="_blank">GitHub</a>
+            <a href="https://github.com/aditya2006magic" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
         
             </div>
         </div>
@@ -604,7 +604,7 @@
             <span class="role">Backend Developer</span>
             <p>"I am excited to make my first open-source contribution and learned how to make a Pull Request today!"
             </p>
-            <a href="https://github.com/ashishagrawalcode" class="card-btn" target="_blank">View My GitHub Profile!</a>
+            <a href="https://github.com/ashishagrawalcode" class="card-btn" target="_blank" rel="noopener noreferrer">View My GitHub Profile!</a>
         
             </div>
         </div>
@@ -615,7 +615,7 @@
             <h2>Pallavi Verulkar</h2>
             <span class="role">frontend developer</span>
             <p>"I am excited to make my first open-source contribution!"</p>
-            <a href="https://github.com/Pallavi960" class="card-btn" target="_blank">View My GitHub Profile!</a>
+            <a href="https://github.com/Pallavi960" class="card-btn" target="_blank" rel="noopener noreferrer">View My GitHub Profile!</a>
         
             </div>
         </div>
@@ -626,7 +626,7 @@
             <h2>Jayesh Thar</h2>
             <span class="role">Contributor</span>
             <p>"Hy there! Let's connect and build..."</p>
-            <a href="https://github.com/jayesh-thar" class="card-btn" target="_blank">GitHub</a>
+            <a href="https://github.com/jayesh-thar" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
         
             </div>
         </div>
@@ -637,7 +637,7 @@
             <h2>Rakhi Dixit</h2>
             <span class="role">Contributor</span>
             <p>"I learned how to make a Pull Request today!"</p>
-            <a href="https://github.com/Rakhi-Dixit03" class="card-btn" target="_blank">GitHub</a>
+            <a href="https://github.com/Rakhi-Dixit03" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
         
             </div>
         </div>
@@ -648,7 +648,7 @@
             <h2>Bhavy Gupta</h2>
             <span class="role">Open Source Contributor</span>
             <p>"Hello! This is my first PR.Happy to connect with U all..."</p>
-            <a href="https://github.com/BhavyGupta12911" class="card-btn" target="_blank">view my GitHub Profile
+            <a href="https://github.com/BhavyGupta12911" class="card-btn" target="_blank" rel="noopener noreferrer">view my GitHub Profile
                 Here!</a>
         
             </div>
@@ -660,7 +660,7 @@
             <h2>Vrishti Kumari</h2>
             <span class="role">Frontend Developer</span>
             <p>"Learning open source one PR at a time 🚀"</p>
-            <a href="https://github.com/Vrishti-vibes" class="card-btn" target="_blank">GitHub</a>
+            <a href="https://github.com/Vrishti-vibes" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
         
             </div>
         </div>
@@ -671,7 +671,7 @@
             <h2>Deepjyoti Saha</h2>
             <span class="role">Frontend + AI Explorer</span>
             <p>"Hy there! Let's connect and build..."</p>
-            <a href="https://github.com/deepjyoti-coder" class="card-btn" target="_blank">GitHub</a>
+            <a href="https://github.com/deepjyoti-coder" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
         
             </div>
         </div>
@@ -682,7 +682,7 @@
             <h2>Yugendra N</h2>
             <span class="role">AIDS- Undergrad , Software Developer</span>
             <p>"Developer passionate about learning and open source"</p>
-            <a href="https://github.com/Yugenjr" class="card-btn" target="_blank">GitHub</a>
+            <a href="https://github.com/Yugenjr" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
         
             </div>
         </div>
@@ -693,7 +693,7 @@
                 <h2>Rohini</h2>
                 <span class="role">Developer</span>
                 <p>"Passionate Contributor"</p>
-                <a href="https://github.com/Rohinibadyal" class="card-btn" target="_blank">Github</a>
+                <a href="https://github.com/Rohinibadyal" class="card-btn" target="_blank" rel="noopener noreferrer">Github</a>
             </div>
         </div>
 
@@ -703,7 +703,7 @@
                 <h2>Vinaykumar</h2>
                 <span class="role">Java Developer</span>
                 <p>"I am excited to make my first open-source contribution!"</p>
-                <a href="https://github.com/vinay-554" class="card-btn" target="_blank">GitHub</a>
+                <a href="https://github.com/vinay-554" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
             </div>
         </div>
 
@@ -713,7 +713,7 @@
             <h2>Harshit Singh</h2>
             <span class="role">Contributor</span>
             <p>"Finally completed my 200 Pull Requests!"</p>
-            <a href="https://github.com/harshitSingh1" class="card-btn" target="_blank">GitHub</a>
+            <a href="https://github.com/harshitSingh1" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
         
             </div>
         </div>
@@ -724,7 +724,7 @@
             <h2>Samina Sultana</h2>
             <span class="role">Frontend Developer</span>
             <p>"Hello world! This is my first PR."</p>
-            <a href="https://github.com/Samina2005" class="card-btn" target="_blank">GitHub</a>
+            <a href="https://github.com/Samina2005" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
         
             </div>
         </div>
@@ -734,7 +734,7 @@
             <h2>Souradeep Chakraborty</h2>
             <span class="role">Contributor</span>
             <p>"Learning full stack and excited to contribute in ECWoC'26"</p>
-            <a href="https://github.com/Souradeep858" class="card-btn" target="_blank">GitHub</a>
+            <a href="https://github.com/Souradeep858" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
         
             </div>
         </div>
@@ -745,7 +745,7 @@
             <h2>Ram Charan</h2>
             <span class="role">Contributor</span>
             <p>"First open-source contribution through ECWoC’26. Excited to learn and build "</p>
-            <a href="https://github.com/print-ramcharan" class="card-btn" target="_blank">GitHub</a>
+            <a href="https://github.com/print-ramcharan" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
         
             </div>
         </div>
@@ -756,7 +756,7 @@
                 <h2>Prachi jain</h2>
                 <span class="role">Contributor</span>
                 <p>"My first open source contribution..& also I learned how to make a Pull Request today!"</p>
-                <a href="http://github.com/prachijainn24/" class="card-btn" target="_blank">Github</a>
+                <a href="http://github.com/prachijainn24/" class="card-btn" target="_blank" rel="noopener noreferrer">Github</a>
             </div>
         </div>
 
@@ -766,7 +766,7 @@
                 <h2>Uppara Sai Maithreyi</h2>
                 <span class="role">Contributor</span>
                 <p>"Hello! This is my first open source contribution."</p>
-                <a href="https://github.com/Sai-maithri" class="card-btn" target="_blank">Github</a>
+                <a href="https://github.com/Sai-maithri" class="card-btn" target="_blank" rel="noopener noreferrer">Github</a>
             </div>
         </div>
 
@@ -776,7 +776,7 @@
                 <h2>Hitesh Rahul</h2>
                 <span class="role">Contributor</span>
                 <p>"I learned how to make a Pull Request today!"</p>
-                <a href="https://github.com/HiteshRahul27" class="card-btn" target="_blank">Github</a>
+                <a href="https://github.com/HiteshRahul27" class="card-btn" target="_blank" rel="noopener noreferrer">Github</a>
             </div>
         </div>
 
@@ -786,7 +786,7 @@
                 <h2>Vaishnav K</h2>
                 <span class="role">Contributor</span>
                 <p>"Exploring open source and learning GitHub and version control along the way."</p>
-                <a href="https://github.com/Vaishnav-K-12" class="card-btn" target="_blank">View Github Profile</a>
+                <a href="https://github.com/Vaishnav-K-12" class="card-btn" target="_blank" rel="noopener noreferrer">View Github Profile</a>
             </div>
         </div>
           
@@ -796,7 +796,7 @@
                 <h2>Ritika Mahato</h2>
                 <span class="role">Open Source Contributor</span>
                 <p>"Hello world! Building skills, one commit."</p>
-               <a href="https://github.com/ritikamahato924" class="card-btn" target="_blank">GitHub</a>
+               <a href="https://github.com/ritikamahato924" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
             </div>
         </div>
 
@@ -806,7 +806,7 @@
                 <h2>Aagman Pal</h2>
                 <span class="role">Developer</span>
                 <p>"Excited to contribute meaningful in real world projects through ECWoC'26!"</p>
-                <a href="https://www.linkedin.com/in/aagman-pal/" class="card-btn" target="_blank">LinkedIn</a>
+                <a href="https://www.linkedin.com/in/aagman-pal/" class="card-btn" target="_blank" rel="noopener noreferrer">LinkedIn</a>
             </div>
         </div>
 
@@ -816,7 +816,7 @@
                 <h2>Nur Hasin Ahammad</h2>
                 <span class="role">Contributor</span>
                 <p>Aspiring AI-Powered Full-Stack Developer</p>
-                <a href="http://github.com/nur-hasin/" class="card-btn" target="_blank">View Profile</a>
+                <a href="http://github.com/nur-hasin/" class="card-btn" target="_blank" rel="noopener noreferrer">View Profile</a>
             </div>
         </div>
         
@@ -826,7 +826,7 @@
                 <h2>Praveen Kumar Vinukonda</h2>
                 <span class="role">Contributor</span>
                 <p>"My journey in open source begins here."</p>
-                <a href="https://github.com/Prvkmr-Daddy-21" class="card-btn" target="_blank">View GitHub Profile</a>
+                <a href="https://github.com/Prvkmr-Daddy-21" class="card-btn" target="_blank" rel="noopener noreferrer">View GitHub Profile</a>
             </div>
         </div>
       
@@ -837,8 +837,8 @@
                 <span class="role">Contributor</span>
                 <p>"Contributing to open source for the first time. Excited to be part of this amazing community!"</p>
                 <div class="card-buttons">
-                    <a href="https://github.com/ayusshs16" class="card-btn" target="_blank">GitHub</a>
-                    <a href="https://www.linkedin.com/in/ayusshsrivastava16/" class="card-btn" target="_blank">LinkedIn</a>
+                    <a href="https://github.com/ayusshs16" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
+                    <a href="https://www.linkedin.com/in/ayusshsrivastava16/" class="card-btn" target="_blank" rel="noopener noreferrer">LinkedIn</a>
                 </div>
             </div>
         </div>
@@ -849,7 +849,7 @@
                 <h2>Varri Chandrasekhar</h2>
                 <span class="role">COntributor</span>
                 <p>"Exploring open source and learning GitHub and version control along the way."</p>
-                <a href="https://github.com/Chandrasekhar-5" class="card-btn" target="_blank">Github</a>
+                <a href="https://github.com/Chandrasekhar-5" class="card-btn" target="_blank" rel="noopener noreferrer">Github</a>
             </div>
         </div>
 
@@ -859,7 +859,7 @@
             <h2>Anvesha</h2>
             <span class="role">Contributor</span>
             <p>"Passionate about coding, collaboration, and making an impact."</p>
-            <a href="https://github.com/anvi-sha675" class="card-btn" target="_blank">GitHub</a>
+            <a href="https://github.com/anvi-sha675" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
         
             </div>
         </div>
@@ -870,7 +870,7 @@
                 <h2>Priyanshu Singh</h2>
                 <span class="role">Contributor</span>
                 <p>"Passionate about building scalable, user-friendly web applications."</p>
-                <a href="https://github.com/PriyanshuSingh00-hub" class="card-btn" target="_blank">
+                <a href="https://github.com/PriyanshuSingh00-hub" class="card-btn" target="_blank" rel="noopener noreferrer">
                       <i class="fab fa-github"></i> GitHub
                 </a>
             </div>
@@ -883,8 +883,8 @@
                 <span class="role">Contributor</span>
                 <p>"Exited for my first open source contribution."</p>
                 <div class="card-buttons">
-                    <a href="https://github.com/SRdash2003" class="card-btn" target="_blank">GitHub</a>
-                    <a href="https://www.linkedin.com/in/soumya-ranjan-dash-01b4b02a8" class="card-btn" target="_blank">LinkedIn</a>
+                    <a href="https://github.com/SRdash2003" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
+                    <a href="https://www.linkedin.com/in/soumya-ranjan-dash-01b4b02a8" class="card-btn" target="_blank" rel="noopener noreferrer">LinkedIn</a>
                 </div>
             </div>
         </div>
@@ -895,7 +895,7 @@
                 <h2>Armaan</h2>
                 <span class="role">Contributor</span>
                 <p>"CSE student passionate about exploring and contributing to Open Source projects."</p>
-                <a href="https://github.com/iarmaanx" class="card-btn" target="_blank">View Github Profile</a>
+                <a href="https://github.com/iarmaanx" class="card-btn" target="_blank" rel="noopener noreferrer">View Github Profile</a>
             </div>
         </div>
 
@@ -905,7 +905,7 @@
                 <h2>Bavanetha</h2>
                 <span class="role">Open Source Enthusiast</span>
                 <p>"Passionate learner crafting solutions in the Open Source universe."</p>
-                <a href="https://github.com/Bavanetha27" class="card-btn" target="_blank">View Github Profile</a>
+                <a href="https://github.com/Bavanetha27" class="card-btn" target="_blank" rel="noopener noreferrer">View Github Profile</a>
             </div>
         </div>
 
@@ -915,7 +915,7 @@
                 <h2>Shreyaushi Das</h2>
                 <span class="role">Developer</span>
                 <p>"Starting my open source journey with ECWoC!"</p>
-                <a href="https://www.linkedin.com/in/shreyaushi-das-/" class="card-btn" target="_blank">Linkedin</a>
+                <a href="https://www.linkedin.com/in/shreyaushi-das-/" class="card-btn" target="_blank" rel="noopener noreferrer">Linkedin</a>
             </div>
         </div>
 
@@ -925,7 +925,7 @@
                 <h2>Suyash Jaiswal</h2>
                 <span class="role">Student Developer</span>
                 <p>"Starting my Open Source journey with ECWoC"</p>
-                <a href="https://github.com/suyash-jaiswal-7" class="card-btn" target="_blank">View Profile</a>
+                <a href="https://github.com/suyash-jaiswal-7" class="card-btn" target="_blank" rel="noopener noreferrer">View Profile</a>
             </div>
         </div>
 
@@ -935,7 +935,7 @@
                 <h2>Priyanshu Singh</h2>
                 <span class="role">Student Developer</span>
                 <p>"Learning software development through open source contributions."</p>
-                <a href="https://github.com/PriyanshuSingh9" class="card-btn" target="_blank">View Profile</a>
+                <a href="https://github.com/PriyanshuSingh9" class="card-btn" target="_blank" rel="noopener noreferrer">View Profile</a>
             </div>
         </div>
 
@@ -945,7 +945,7 @@
                 <h2>Rudra Agrawal</h2>
                 <span class="role">Full Stack Developer</span>
                 <p>"I am excited to make my first open-source contribution!"</p>
-                <a href="https://github.com/Cypher-0071" class="card-btn" target="_blank">View Profile</a>
+                <a href="https://github.com/Cypher-0071" class="card-btn" target="_blank" rel="noopener noreferrer">View Profile</a>
             </div>
         </div>
 
@@ -955,7 +955,7 @@
                 <h2>Aditya Kumar</h2>
                 <span class="role">Full Stack Developer</span>
                 <p>"I am excited to make my first open-source contribution!"</p>
-                <a href="https://github.com/Adityakumarchaurasiya" class="card-btn" target="_blank">View Profile</a>
+                <a href="https://github.com/Adityakumarchaurasiya" class="card-btn" target="_blank" rel="noopener noreferrer">View Profile</a>
             </div>
         </div>
 
@@ -965,7 +965,7 @@
             <h2>Pavan Karthik</h2>
             <span class="role">Contributor</span>
             <p>"Exploring open source through issues, PRs, and real work."</p>
-            <a href="https://github.com/pavanakarthik12" class="card-btn" target="_blank">View Profile</a>
+            <a href="https://github.com/pavanakarthik12" class="card-btn" target="_blank" rel="noopener noreferrer">View Profile</a>
         
             </div>
         </div>
@@ -976,7 +976,7 @@
                 <h2>Sai Srujan</h2>
                 <span class="role">Student Developer</span>
                 <p>"Aspiring Cloud And Devops Engineer | IT Student"</p>
-                <a href="https://github.com/saiusesgithub" class="card-btn" target="_blank">GitHub</a>
+                <a href="https://github.com/saiusesgithub" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
             </div>
         </div>
 
@@ -986,7 +986,7 @@
                 <h2>Vanshika Soni</h2>
                 <span class="role">Contributor</span>
                 <p> passionate about web development </p>
-                <a href="https://github.com/vxnxhika-73" class="card-btn" target="_blank"> View GitHub Profile</a>
+                <a href="https://github.com/vxnxhika-73" class="card-btn" target="_blank" rel="noopener noreferrer"> View GitHub Profile</a>
             </div>
         </div>
         <div class="card">
@@ -995,7 +995,7 @@
                 <h2>Sukhmanpreet Kaur</h2>
                 <span class="role">Open source Enthusiast</span>
                 <p>"Excited to contribute to open source projects."</p>
-                <a href="https://github.com/Sukhmanpreetkaur18" class="card-btn" target="_blank">GitHub</a>
+                <a href="https://github.com/Sukhmanpreetkaur18" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
             </div>
         </div>
 
@@ -1005,7 +1005,7 @@
                 <h2>Nidhish Arora</h2>
                 <span class="role">Open Source Enthusiast</span>
                 <p>"Hello World! This is my first pull request."</p>
-                <a href="https://github.com/Nidhisharora" class="card-btn" target="_blank">Github</a>
+                <a href="https://github.com/Nidhisharora" class="card-btn" target="_blank" rel="noopener noreferrer">Github</a>
             </div>
         </div>
 
@@ -1015,7 +1015,7 @@
                 <h2>Muhammad Sohaib</h2>
                 <span class="role">Software Engineer</span>
                 <p>Coding is my craft; I transform ideas into real-world applications.</p>
-                <a href="https://github.com/sohaibkundi2" class="card-btn" target="_blank">View Github</a>
+                <a href="https://github.com/sohaibkundi2" class="card-btn" target="_blank" rel="noopener noreferrer">View Github</a>
             </div>
         </div>
 
@@ -1025,7 +1025,7 @@
                 <h2>Rishabh Mishra</h2>
                 <span class="role">Developer</span>
                 <p>"Passionate learner crafting solutions in the Open Source universe.""</p>
-                <a href="https://github.com/rishabh0510rishabh" class="card-btn" target="_blank">View Profile</a>
+                <a href="https://github.com/rishabh0510rishabh" class="card-btn" target="_blank" rel="noopener noreferrer">View Profile</a>
             </div>
         </div>
 
@@ -1035,7 +1035,7 @@
                 <h2>Shubham Sagar</h2>
                 <span class="role">Fullstack Developer</span>
                 <p>"Hello world! i love to talk about open source and get connected"</p>
-                <a href="https://github.com/shubhIam-dev" class="card-btn" target="_blank">GitHub</a>
+                <a href="https://github.com/shubhIam-dev" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
             </div>
         </div>
 
@@ -1045,7 +1045,7 @@
                 <h2>Tannistha Sarkar</h2>
                 <span class="role">ML Dev</span>
                 <p>"My first open-source contribution through ECWoC!"</p>
-                <a href="https://github.com/Tannistha24" class="card-btn" target="_blank">Github</a>
+                <a href="https://github.com/Tannistha24" class="card-btn" target="_blank" rel="noopener noreferrer">Github</a>
             </div>
         </div>
 
@@ -1055,7 +1055,7 @@
                 <h2>Madapathi Sai Sathvik</h2>
                 <span class="role">Student Developer</span>
                 <p>Build Tech Solutions</p>
-                <a href="https://github.com/Saisathvik94" class="card-btn" target="_blank">GitHub</a>
+                <a href="https://github.com/Saisathvik94" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
             </div>
         </div>
 
@@ -1065,7 +1065,7 @@
             <h2>Furkan Farooqui</h2>
             <span class="role">Contributor</span>
             <p>"Hello! This is my first PR through ECWoC’26."</p>
-            <a href="https://github.com/FurkanFarooqui19" class="card-btn" target="_blank">GitHub</a>
+            <a href="https://github.com/FurkanFarooqui19" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
         
             </div>
         </div>
@@ -1076,7 +1076,7 @@
                 <h2>Mohd Maaz Gani</h2>
                 <span class="role">Open Source Contributor</span>
                 <p>"Just a tech enthusiast turning caffeine and code into AI-powered web solutions."</p>
-                <a href="https://github.com/mohdmaazgani" class="card-btn" target="_blank">GitHub</a>
+                <a href="https://github.com/mohdmaazgani" class="card-btn" target="_blank" rel="noopener noreferrer">GitHub</a>
             </div>
         </div>
         


### PR DESCRIPTION
## Description

Adds `rel="noopener noreferrer"` to all `<a>` elements that use `target="_blank"` but lacked this security attribute. Without `rel="noopener"`, the destination page gains a reference to the opener window via `window.opener`, enabling reverse tabnapping attacks where the destination can redirect the original tab to a malicious URL.

The contributor card template block was also updated so new contributor submissions include the correct `rel` attribute from the start.

Fixes: #4818

---

## Type of Change

- [x] Bug fix (security vulnerability remediation)

---

## How Has This Been Tested?

- Verified all `target="_blank"` anchors now include `rel="noopener noreferrer"` using grep verification
- Confirmed no anchors were missed: all 80 instances of `target="_blank"` now carry the correct `rel` attribute
- Confirmed no double-application of the attribute on the one anchor that previously had a partial `rel` value

---

## Screenshots

This is a security fix with no visual change to the rendered UI.

---

## Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes
- [x] This PR does not introduce breaking changes

---

## Additional Notes

The OWASP Top 10 lists reverse tabnapping as a well-known vulnerability. All browsers are affected; older browsers that do not implicitly add `noopener` are especially vulnerable. This change eliminates the vulnerability for all 80 affected anchor elements in index.html.