### PR TITLE
Fix text visibility in light theme

### DIFF
--- a/css/contribute.css
+++ b/css/contribute.css
@@ -204,7 +204,7 @@ body.light-mode {
 .step-card h3 {
     font-size: 1.5rem;
     margin: 0 0 15px 0;
-    color: #ffffff;
+    color: var(--text-primary);
     z-index: 1;
     transition: transform 0.45s ease;
 }
@@ -215,7 +215,7 @@ body.light-mode {
 
 /* Content */
 .step-content {
-    color: rgba(255, 255, 255, 0.7);
+    color: var(--text-secondary);
     line-height: 1.6;
     margin-bottom: 20px;
     z-index: 1;
@@ -248,7 +248,7 @@ body.light-mode {
     padding: 15px;
     border-radius: 10px;
     font-size: 0.9rem;
-    color: #e9e5ff;
+    color: var(--text-primary);
     display: flex;
     align-items: center;
     gap: 10px;


### PR DESCRIPTION
## 📌 Description
This PR fixes text visibility issues in light mode on the Contribute page.

Previously, some elements such as step headings, content text, and the purple tip box used hard-coded light colors (#ffffff, rgba white values), which caused poor contrast and unreadable text in light theme.

This update replaces hard-coded colors with CSS variables:
- `var(--text-primary)`
- `var(--text-secondary)`

This ensures proper visibility in both dark and light modes.

Fixes: #4294

---

## 🔧 Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor / Code cleanup
- [x] 🎨 UI / Styling change
- [ ] 🚀 Other (please describe):

---

## 🧪 How Has This Been Tested?

- [x] Manual testing
- [ ] Automated tests
- [ ] Not tested (please explain why)

### Testing Details:
- Verified in Dark Mode (no visual regression)
- Verified in Light Mode (text now clearly visible)
- Tested responsiveness in Desktop and Mobile view

---

## 📸 Screenshots Checklist (Mandatory)
- [x] Before changes (for bug fixes)
 
<img width="1914" height="927" alt="Screenshot 2026-02-25 214335" src="https://github.com/user-attachments/assets/6814dfc6-554e-4da4-891e-60cdd1fd10a1" />

- [x] After changes
<img width="1888" height="984" alt="Screenshot 2026-02-25 213825" src="https://github.com/user-attachments/assets/ff1320ae-ed7b-408b-ac46-b08aed46e2e4" />

---

## ✅ Checklist

- [x] My code follows the project’s coding style
- [x] I have tested my changes
- [ ] I have updated documentation where necessary (not required)
- [x] This PR does not introduce breaking changes

---

## 📝 Additional Notes

This change improves accessibility and ensures consistent theme behavior by removing hard-coded color values and relying on theme variables instead.