### PR TITLE
Add Clear All Data Button with Confirmation Dialog

### DIFF
--- a/projects/cognitive-switching-cost-tracker/index.html
+++ b/projects/cognitive-switching-cost-tracker/index.html
@@ -65,6 +65,11 @@
                     </div>
                     <button type="submit" class="btn-primary">Log Switch</button>
                 </form>
+                
+                <!-- Clear All Data Button -->
+                <div class="clear-data-container">
+                    <button id="clear-data-btn" class="btn-danger">🗑️ Clear All Data</button>
+                </div>
             </div>
 
             <div class="charts-section">
@@ -88,6 +93,18 @@
             <div id="insights-content">
                 <p>💡 <strong>Did you know?</strong> Research shows that context switching can cost up to 25 minutes of productive time per switch.</p>
                 <p>🎯 <strong>Tip:</strong> Try to batch similar tasks together and minimize interruptions during deep work sessions.</p>
+            </div>
+        </div>
+    </div>
+
+    <!-- Confirmation Modal -->
+    <div id="confirm-modal" class="modal">
+        <div class="modal-content">
+            <h3>⚠️ Clear All Data</h3>
+            <p>Are you sure? This will permanently delete all your switching history and reset the app to its initial state. This action cannot be undone.</p>
+            <div class="modal-buttons">
+                <button id="modal-cancel" class="btn-secondary">Cancel</button>
+                <button id="modal-confirm" class="btn-danger">Yes, Clear All Data</button>
             </div>
         </div>
     </div>

--- a/projects/cognitive-switching-cost-tracker/style.css
+++ b/projects/cognitive-switching-cost-tracker/style.css
@@ -233,3 +233,128 @@ header p {
         height: 250px;
     }
 }
+
+/* Add these styles to your existing CSS file */
+
+.clear-data-container {
+    margin-top: 20px;
+    border-top: 1px solid #e1e5e9;
+    padding-top: 20px;
+}
+
+.btn-danger {
+    background: linear-gradient(135deg, #e74c3c 0%, #c0392b 100%);
+    color: white;
+    border: none;
+    padding: 12px 24px;
+    border-radius: 8px;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+}
+
+.btn-danger:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(231, 76, 60, 0.3);
+}
+
+.btn-secondary {
+    background: #95a5a6;
+    color: white;
+    border: none;
+    padding: 10px 20px;
+    border-radius: 6px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s ease;
+}
+
+.btn-secondary:hover {
+    background: #7f8c8d;
+}
+
+/* Modal Styles */
+.modal {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    z-index: 2000;
+    align-items: center;
+    justify-content: center;
+    animation: fadeIn 0.3s ease;
+}
+
+.modal.show {
+    display: flex;
+}
+
+.modal-content {
+    background: white;
+    padding: 30px;
+    border-radius: 15px;
+    max-width: 400px;
+    width: 90%;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+    animation: slideUp 0.3s ease;
+}
+
+.modal-content h3 {
+    color: #e74c3c;
+    margin-bottom: 15px;
+    font-size: 1.5rem;
+}
+
+.modal-content p {
+    margin-bottom: 25px;
+    line-height: 1.6;
+    color: #666;
+}
+
+.modal-buttons {
+    display: flex;
+    gap: 10px;
+    justify-content: flex-end;
+}
+
+.modal-buttons button {
+    padding: 10px 20px;
+    min-width: 100px;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+@keyframes slideUp {
+    from {
+        transform: translateY(20px);
+        opacity: 0;
+    }
+    to {
+        transform: translateY(0);
+        opacity: 1;
+    }
+}
+
+/* Update existing notification styles */
+@keyframes slideIn {
+    from { transform: translateX(100%); opacity: 0; }
+    to { transform: translateX(0); opacity: 1; }
+}
+
+@keyframes slideOut {
+    from { transform: translateX(0); opacity: 1; }
+    to { transform: translateX(100%); opacity: 0; }
+}


### PR DESCRIPTION
## #5667 issue resolved

## Description
This PR adds a "Clear All Data" button that allows users to reset their tracking data without manually clearing browser storage. This addresses user feedback about the inability to easily reset the app for testing or privacy purposes.

## Problem Solved

- Users previously had no way to reset their task switching history without using browser developer tools
- New users testing the app couldn't easily clear demo data
- Privacy-conscious users couldn't quickly delete their data when needed

## Implementation

- Added a "Clear All Data" button in the stats overview section
- Implemented a confirmation modal with warning message
- Added functionality to clear localStorage and reset the entire UI to initial state
- Added success notification after data is cleared

## Screenshot
<img width="1900" height="820" alt="image" src="https://github.com/user-attachments/assets/b6497197-8729-4760-a33f-3b81e7502470" />
