### PR TITLE
Add Weekly Report Generation Feature

### DIFF
--- a/projects/cognitive-switching-cost-tracker/index.html
+++ b/projects/cognitive-switching-cost-tracker/index.html
@@ -7,6 +7,8 @@
     <link rel="stylesheet" href="style.css">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-sankey@0.12.0/dist/chartjs-chart-sankey.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 </head>
 <body>
     <div class="container">
@@ -226,6 +228,7 @@
                 <div class="insights-buttons">
                     <button id="export-data-btn" class="btn-secondary">📥 Export Data</button>
                     <button id="import-data-btn" class="btn-secondary">📤 Import Data</button>
+                    <button id="weekly-report-btn" class="btn-primary">📊 Generate Weekly Report</button>
                 </div>
             </div>
             <div id="insights-content">
@@ -284,6 +287,20 @@
             <div class="modal-buttons">
                 <button id="modal-snooze" class="btn-secondary">Snooze (30 min)</button>
                 <button id="modal-dismiss" class="btn-primary">OK, Take Break</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Weekly Report Modal -->
+    <div id="weekly-report-modal" class="modal">
+        <div class="modal-content weekly-report-content">
+            <h3>📊 Weekly Productivity Report</h3>
+            <div class="report-preview" id="report-preview">
+                <div class="report-loading">Generating your personalized report...</div>
+            </div>
+            <div class="modal-buttons">
+                <button id="report-cancel" class="btn-secondary">Close</button>
+                <button id="report-download" class="btn-primary">⬇️ Download PDF</button>
             </div>
         </div>
     </div>

--- a/projects/cognitive-switching-cost-tracker/style.css
+++ b/projects/cognitive-switching-cost-tracker/style.css
@@ -237,6 +237,30 @@ header p {
     color: #4a90e2;
 }
 
+.insights-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 20px;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.insights-buttons {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+
+.insights-buttons .btn-primary {
+    width: auto;
+    background: linear-gradient(135deg, #27ae60 0%, #2ecc71 100%);
+}
+
+.insights-buttons .btn-primary:hover {
+    box-shadow: 0 4px 12px rgba(46, 204, 113, 0.3);
+}
+
 .flow-analysis-section {
     margin-top: 30px;
 }
@@ -405,8 +429,10 @@ tr:last-child td {
     background: white;
     padding: 30px;
     border-radius: 15px;
-    max-width: 400px;
+    max-width: 500px;
     width: 90%;
+    max-height: 80vh;
+    overflow-y: auto;
     box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
     animation: slideUp 0.3s ease;
 }
@@ -427,6 +453,7 @@ tr:last-child td {
     display: flex;
     gap: 10px;
     justify-content: flex-end;
+    flex-wrap: wrap;
 }
 
 .modal-buttons button {
@@ -460,18 +487,6 @@ tr:last-child td {
     to { transform: translateX(100%); opacity: 0; }
 }
 
-.insights-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 20px;
-}
-
-.insights-buttons {
-    display: flex;
-    gap: 10px;
-}
-
 #import-summary {
     background: #f8f9fa;
     padding: 15px;
@@ -483,6 +498,157 @@ tr:last-child td {
 
 #import-summary strong {
     color: #4a90e2;
+}
+
+.weekly-report-content {
+    max-width: 600px;
+}
+
+.weekly-report-content h3 {
+    color: #27ae60 !important;
+    border-bottom: 2px solid #27ae60;
+    padding-bottom: 10px;
+}
+
+.report-preview {
+    background: #f8f9fa;
+    border-radius: 8px;
+    padding: 20px;
+    margin: 20px 0;
+    max-height: 400px;
+    overflow-y: auto;
+    font-size: 0.95rem;
+    line-height: 1.6;
+}
+
+.report-loading {
+    text-align: center;
+    color: #666;
+    padding: 40px;
+}
+
+.report-section {
+    margin-bottom: 20px;
+    padding-bottom: 15px;
+    border-bottom: 1px solid #e1e5e9;
+}
+
+.report-section:last-child {
+    border-bottom: none;
+}
+
+.report-section h4 {
+    color: #333;
+    margin-bottom: 10px;
+    font-size: 1.1rem;
+}
+
+.report-section h4 i {
+    margin-right: 8px;
+}
+
+.report-stat {
+    display: flex;
+    justify-content: space-between;
+    margin: 8px 0;
+    padding: 5px 0;
+}
+
+.report-stat .label {
+    color: #666;
+    font-weight: 500;
+}
+
+.report-stat .value {
+    font-weight: 600;
+    color: #333;
+}
+
+.report-stat .value.highlight {
+    color: #27ae60;
+    font-size: 1.2rem;
+}
+
+.report-stat .value.warning {
+    color: #e74c3c;
+}
+
+.recommendation-item {
+    background: white;
+    border-left: 4px solid #4a90e2;
+    padding: 12px;
+    margin: 10px 0;
+    border-radius: 4px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+}
+
+.recommendation-item i {
+    color: #4a90e2;
+    margin-right: 8px;
+}
+
+.day-badge {
+    display: inline-block;
+    padding: 4px 10px;
+    border-radius: 20px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    margin: 2px 0;
+}
+
+.day-badge.best {
+    background: #d4edda;
+    color: #155724;
+}
+
+.day-badge.worst {
+    background: #f8d7da;
+    color: #721c24;
+}
+
+.interruption-item {
+    display: flex;
+    align-items: center;
+    margin: 8px 0;
+}
+
+.interruption-name {
+    width: 120px;
+    font-weight: 500;
+}
+
+.interruption-bar-container {
+    flex: 1;
+    height: 20px;
+    background: #e1e5e9;
+    border-radius: 10px;
+    margin: 0 10px;
+    overflow: hidden;
+}
+
+.interruption-bar {
+    height: 100%;
+    background: linear-gradient(90deg, #e74c3c, #f39c12);
+    border-radius: 10px;
+    transition: width 0.3s ease;
+}
+
+.interruption-percent {
+    width: 50px;
+    font-weight: 600;
+    color: #666;
+}
+
+.comparison-positive {
+    color: #27ae60;
+}
+
+.comparison-negative {
+    color: #e74c3c;
+}
+
+.comparison-neutral {
+    color: #f39c12;
 }
 
 @media (max-width: 768px) {
@@ -507,6 +673,14 @@ tr:last-child td {
     }
     
     .modal-buttons button {
+        width: 100%;
+    }
+    
+    .insights-buttons {
+        width: 100%;
+    }
+    
+    .insights-buttons .btn-primary {
         width: 100%;
     }
 }


### PR DESCRIPTION
## #5691 issue resolved

## Description
This PR adds a Generate Weekly Report button to the insights section that creates comprehensive PDF reports with detailed productivity analytics and recommendations.\

## Implemented

- Added Generate Weekly Report button in the insights section UI
- Created comprehensive PDF report generation with:

  - Most common interruption sources with percentages
  - Best and worst productivity days of the week
  - Personalized recommendations based on user patterns
  - Week-over-week comparison metrics
  - Proper formatting with embedded charts

## Screenshot
<img width="1862" height="815" alt="image" src="https://github.com/user-attachments/assets/97ec9213-827c-4ad9-bddd-2c8957c734ee" />
