### PR TITLE
Add Friendly Empty State UI for Activity History

### DIFF
--- a/projects/cognitive-saturation-alert/cognitive-saturation-alert.css
+++ b/projects/cognitive-saturation-alert/cognitive-saturation-alert.css
@@ -540,3 +540,81 @@
     border-radius: 12px;
     margin-left: 10px;
 }
+
+.empty-state {
+    text-align: center;
+    padding: 60px 20px;
+    background: white;
+    border-radius: 12px;
+    box-shadow: 0 5px 15px rgba(0,0,0,0.05);
+    animation: fadeIn 0.5s ease;
+}
+
+.empty-state i {
+    font-size: 5em;
+    color: #cbd5e0;
+    margin-bottom: 20px;
+    background: linear-gradient(135deg, #667eea20 0%, #764ba220 100%);
+    padding: 20px;
+    border-radius: 50%;
+    display: inline-block;
+}
+
+.empty-state h3 {
+    color: #2d3748;
+    font-size: 1.8em;
+    margin-bottom: 15px;
+    font-weight: 600;
+}
+
+.empty-state p {
+    color: #718096;
+    font-size: 1.1em;
+    margin-bottom: 30px;
+    max-width: 450px;
+    margin-left: auto;
+    margin-right: auto;
+    line-height: 1.6;
+}
+
+.empty-state .log-btn {
+    width: auto;
+    padding: 14px 35px;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    border: none;
+    color: white;
+    font-size: 1.1em;
+    font-weight: 600;
+    border-radius: 50px;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    box-shadow: 0 5px 15px rgba(102, 126, 234, 0.3);
+}
+
+.empty-state .log-btn:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 8px 25px rgba(102, 126, 234, 0.4);
+}
+
+.empty-state .log-btn i {
+    font-size: 1.1em;
+    color: white;
+    margin: 0;
+    padding: 0;
+    background: none;
+    box-shadow: none;
+}
+
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+        transform: translateY(20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}


### PR DESCRIPTION
# #5833 issue resolved

##  Description
This PR adds a friendly empty state message to the activity history section when no cognitive activities have been logged yet. Currently, first-time users see a blank empty space, which provides no guidance on how to start using the feature.

## Changes Made

- Added conditional check in renderHistory() method to display empty state when this.activities array is empty
- Created CSS styles for empty state with smooth fade-in animation
- Added brain icon and encouraging text explaining the purpose of activity logging
- Implemented call-to-action button that smoothly scrolls to the log section
- Added visual feedback (highlight effect) when CTA button is clicked
- Enhanced activity items with icons for better visual consistency

## Screenshot
<img width="1897" height="828" alt="image" src="https://github.com/user-attachments/assets/893f7985-89da-4845-98de-de8dc7575c45" />
